### PR TITLE
Fix: Form validation on optional, empty fields of types 'Element\Url' and 'OmekaElement\PropertySelect'

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -484,6 +484,13 @@ class ConfigForm extends Form
             ])
         ;
 
+        // Use Laminas's input filter for URL validation on certain optional fields
+        $inputFilter = $this->getInputFilter();
+        $inputFilter->add([
+            'name' => 'imageserver_info_rights_url',
+            'required' => false,
+            'allow_empty' => true, // Allow empty strings to pass Laminas Uri validation
+        ]);
     }
 
     /**

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -484,13 +484,27 @@ class ConfigForm extends Form
             ])
         ;
 
-        // Use Laminas's input filter for URL validation on certain optional fields
+        // Fix optional fields whose element types default to required=true :
+        // - Field type 'Element\Url' uses a Uri validator that rejects empty strings.
+        // - Field type 'OmekaElement\PropertySelect' inherits required=true from Laminas Select.
+        // Both must be overridden so leaving a field empty does not abort saving the config form.
         $inputFilter = $this->getInputFilter();
+        // Field type 'Element\Url'
         $inputFilter->add([
             'name' => 'imageserver_info_rights_url',
             'required' => false,
-            'allow_empty' => true, // Allow empty strings to pass Laminas Uri validation
+            'allow_empty' => true,
         ]);
+        // Field type 'OmekaElement\PropertySelect'
+        foreach ($this as $element) {
+            if ($element instanceof \Omeka\Form\Element\AbstractVocabularyMemberSelect) {
+                $inputFilter->add([
+                    'name' => $element->getName(),
+                    'required' => false,
+                    'allow_empty' => true,
+                ]);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Note

This fix solves the issue described at https://github.com/Daniel-KM/Omeka-S-module-ImageServer/issues/9
The fix applies to both modules **ImageServer** and **IiifServer**

The PR is being described in the corresponding PR at the IiifServer repo https://github.com/Daniel-KM/Omeka-S-module-IiifServer/pull/48